### PR TITLE
Slightly improved version of Transient storage with view functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,18 @@ Associate `label` to `number` for the duration of the tx.
 ```solidity
 loadFromCache(string label)
 ```
+Return the number associated to `label` if there is any, `0` otherwise
+
+## Transient storage with view functions - Slightly Improved
+
+_store/load pair to remember data during a tx without writing to storage. Still very gas expensive, do not use in real life. store + load of one uint256 will consume around 600k gas__
+
+```solidity
+storeInCache2(string label, uint256 number) view
+```
+Associate `label` to `number` for the duration of the tx.
+
+```solidity
+loadFromCache2(string label)
+```
 Return the number associated to `label` if there is any, `0` otherwise.

--- a/src/CacheDetector.sol
+++ b/src/CacheDetector.sol
@@ -94,9 +94,37 @@ contract CacheDetector {
     }
   }
 
+  // Store number with label
+  function storeInCache2(string calldata label, uint256 number) external view {
+    uint slot = dataSlot(label, true);
+    uint index = 0;
+    while (number > 0) {
+      if(number%2 == 1){
+          isSlotWarm(slot + index);
+      }
+      number = number >> 1;
+      index++;
+    }
+  }
+
   // Read number with label
   function loadFromCache(string calldata label) external view returns (uint) {
     return stealthCountCalls(dataSlot(label, false));
+  }
+
+  // Read number with label
+  function loadFromCache2(string calldata label) external view returns (uint) {
+    uint res;
+    uint mask = 1;
+    uint slot = dataSlot(label, false);
+    for(uint index = 0; index < 256; index++){
+        (bool warm, uint data) = stealthLoadWithCacheState(slot + index);
+        if(warm){
+            res |= mask;
+        }
+        mask = mask << 1;
+    }
+    return res;
   }
 
   // Utility: get data slot from label

--- a/test/CacheDetector.t.sol
+++ b/test/CacheDetector.t.sol
@@ -49,6 +49,23 @@ contract CacheDetectorTest is Test {
     assertEq(cd.loadFromCache("b"), 0);
   }
 
+  function test_view_storage2(string memory label, uint256 num1, uint256 num2) public {
+//    string memory label = "label";
+//    uint256 num1 = 4321;
+//    uint256 num2 = 63000;
+
+    vm.assume(keccak256(bytes(label)) != keccak256("b2"));
+    vm.assume(bytes(label).length != 0);
+    cd.storeInCache2(label, num1);
+    assertEq(cd.loadFromCache2(label), num1);
+    assertEq(cd.loadFromCache2(label), num1);
+    assertEq(cd.loadFromCache2("b2"), 0);
+    cd.storeInCache2(label, num2);
+    assertEq(cd.loadFromCache2(label), num2);
+    assertEq(cd.loadFromCache2(label), num2);
+    assertEq(cd.loadFromCache2("b2"), 0);
+  }
+
   function test_countCalls_simple() public {
     assertEq(cd.countCalls(), 1);
     assertEq(cd.countCalls(), 2);


### PR DESCRIPTION
Hi @adhusson ,

very nice article you wrote. I thought I would point out that the `Transient storage with view functions` could be improved. It saves 95% of gas on average in the test cases. The new version is storing the number in binary format. Now it "just" costs ~600k gas to write and read a uint256. :wink: 

Anyway, having fun with EVM as you said. 

Have a nice day.